### PR TITLE
Add option to avoid parsing API response

### DIFF
--- a/lib/ditto/client.rb
+++ b/lib/ditto/client.rb
@@ -7,16 +7,21 @@ module Ditto
     end
 
     def find(url, id)
-      response = Net::HTTP.get_response(find_uri(url, id))
+      code, body = find_raw(url, id)
 
-      case response.code
+      case code
       when "200"
-        Image.new(JSON.parse(response.body, symbolize_names: true))
+        Image.new(JSON.parse(body, symbolize_names: true))
       when "408"
         raise ImageTimeoutError
       when "415"
         raise InvalidImageError
       end
+    end
+
+    def find_raw(url, id)
+      response = Net::HTTP.get_response(find_uri(url, id))
+      [response.code, response.body]
     end
 
     def find_uri(url, id)

--- a/spec/lib/ditto/client_spec.rb
+++ b/spec/lib/ditto/client_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe Ditto::Client do
 
   let(:client_id) { "abc123" }
   let(:client) { Ditto::Client.new(client_id) }
+  let(:url) { "http://www.example.com/foo.jpg" }
+  let(:image_id) { "1234" }
 
   describe "#find" do
-    let(:url) { "http://www.example.com/foo.jpg" }
-    let(:image_id) { "1234" }
     let(:response) { ok_response(response_body) }
 
     subject(:image) { client.find(url, image_id) }
@@ -72,6 +72,16 @@ RSpec.describe Ditto::Client do
             an_object_having_attributes(
               brand: "Boston_Red_Sox", confidence: "Medium")))
       end
+    end
+  end
+
+  describe "#find_raw" do
+    it "returns the response code and body without parsing" do
+      response_body = sample_image(url, image_id)
+      response = ok_response(response_body)
+      expect(Net::HTTP).to receive(:get_response).and_return(response)
+
+      expect(client.find_raw(url, image_id)).to eq(["200", response_body])
     end
   end
 


### PR DESCRIPTION
This is useful for clients that do not need to parse the results
right away and want to save the results in their raw format, or
if a client wants to handle error codes directly rather than
raising an exception.

It also provides an option for accessing new fields that have been
added to the API response but haven't been added to the parser for
this gem.